### PR TITLE
fix: Change role from 'system' to 'assistant' in prompt responses

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -44,7 +44,7 @@ export function setupPrompts(server: Server) {
         return {
           messages: [
             {
-              role: 'system',
+              role: 'assistant',
               content: {
                 type: 'text',
                 text: `あなたは国会議事録検索システムのMCPツールを使用して、ユーザーの質問に答えるアシスタントです。
@@ -85,7 +85,7 @@ export function setupPrompts(server: Server) {
         return {
           messages: [
             {
-              role: 'system',
+              role: 'assistant',
               content: {
                 type: 'text',
                 text: `国会議事録検索の専門アシスタントとして、以下の点に注意して検索を実行してください：
@@ -122,7 +122,7 @@ ${args?.query || '検索したい内容'}`
         return {
           messages: [
             {
-              role: 'system',
+              role: 'assistant',
               content: {
                 type: 'text',
                 text: `発言パターン分析の専門家として、以下の手順で分析を行ってください：
@@ -169,7 +169,7 @@ ${args?.target || '分析対象'}`
         return {
           messages: [
             {
-              role: 'system',
+              role: 'assistant',
               content: {
                 type: 'text',
                 text: `法案審議追跡の専門家として、以下の手順で追跡を行ってください：
@@ -219,7 +219,7 @@ ${args?.bill || '追跡したい法案'}`
         return {
           messages: [
             {
-              role: 'system',
+              role: 'assistant',
               content: {
                 type: 'text',
                 text: `特定の発言者の検索を行う際は、以下の点に注意してください：
@@ -265,7 +265,7 @@ ${args?.context || ''}`
         return {
           messages: [
             {
-              role: 'system',
+              role: 'assistant',
               content: {
                 type: 'text',
                 text: `特定のトピックに関する国会議論を検索する際のガイドライン：


### PR DESCRIPTION
Claude Desktopでプロンプトを利用してみたところ、以下のエラーが出たので修正してみました。

```
Error getting prompt: [{ "received": "system", "code":
"invalid_enum_value", "options": [ "user", "assistant" ], "path": X [ "messages", 0, "role" ], "message": "Invalid enum value.
Expected 'user' | 'assistant', received 'system'" } ]
```

---------
This pull request updates the role used in prompt message templates within the `setupPrompts` function in `src/prompts.ts`. Specifically, it changes the role from `'system'` to `'assistant'` for all generated prompt messages. This ensures that the prompts are correctly attributed to the assistant role, which may be required for proper functioning with certain LLM APIs or to better reflect the intended conversational context.

**Prompt role updates:**

* Changed the `role` property from `'system'` to `'assistant'` in all prompt message templates within the `setupPrompts` function in `src/prompts.ts`. [[1]](diffhunk://#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9L47-R47) [[2]](diffhunk://#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9L88-R88) [[3]](diffhunk://#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9L125-R125) [[4]](diffhunk://#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9L172-R172) [[5]](diffhunk://#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9L222-R222) [[6]](diffhunk://#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9L268-R268)